### PR TITLE
Add thirdparty.exclude config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ module.exports = {
 
       thirdParty: {
         includePrivate: true, // Default is false.
+        // Optional.  Accepts strings and RegExp.
+        exclude: ["packageName", /rollup-plugin.*/],
         output: {
           file: path.join(__dirname, 'dist', 'dependencies.txt'),
           encoding: 'utf-8', // Default is utf-8.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -281,6 +281,17 @@ interface ThirdPartyOptions {
   includePrivate?: boolean;
 
   /**
+   * List of strings and regular expressions to match against the dependency names to exclude from the output.
+   * Checks for partial string match.
+   *
+   * @example
+   *   {
+   *     exclude: ['rollup-plugin', /^my-[c|C]ustom-package$/]
+   *   }
+   */
+  exclude?: (string | RegExp)[]
+
+  /**
    * Ensures that dependencies does not violate any license restriction.
    *
    * For example, suppose you want to limit dependencies with MIT or Apache-2.0

--- a/src/license-plugin-option.js
+++ b/src/license-plugin-option.js
@@ -63,6 +63,11 @@ const SCHEMA = {
     validators.object({
       includePrivate: validators.boolean(),
 
+      exclude: validators.array([
+        validators.string(),
+        validators.regExp(),
+      ]),
+
       allow: [
         validators.string(),
         validators.func(),

--- a/src/license-plugin.js
+++ b/src/license-plugin.js
@@ -301,10 +301,29 @@ class LicensePlugin {
       return;
     }
 
+    const exclude = thirdParty.exclude || [];
     const includePrivate = thirdParty.includePrivate || false;
     const outputDependencies = _.chain(this._dependencies)
         .values()
-        .filter((dependency) => includePrivate || !dependency.private)
+        .filter((dependency) => {
+          // Check if the dependency is in the exclude list.
+          // The exclude list supports strings and regex, check for each.
+          if (
+            exclude.some((e) => {
+              if (
+                (typeof e === 'string' && dependency.name.includes(e)) ||
+                (e instanceof RegExp && e.test(dependency.name))
+              ) {
+                return true;
+              }
+              return false;
+            })
+          ) {
+            // Exclude the dependency if the name matched anything in the exclude list.
+            return false;
+          }
+          return includePrivate || !dependency.private;
+        })
         .value();
 
     if (_.isFunction(thirdParty)) {

--- a/src/schema-validators.js
+++ b/src/schema-validators.js
@@ -94,6 +94,16 @@ function isObject(value) {
   return _.isObject(value) && !isArray(value) && !isFunction(value) && !isNil(value) && !isString(value) && !isNumber(value);
 }
 
+/**
+ * Check if given value is a `RegExp`.
+ *
+ * @param {*} value The value to check.
+ * @return {boolean} `true` if `value` is a plain object. `false` otherwise.
+ */
+function isRegExp(value) {
+  return _.isRegExp(value);
+}
+
 export const validators = {
   string() {
     return {
@@ -137,6 +147,15 @@ export const validators = {
       message: 'must be an array',
       schema,
       test: isArray,
+    };
+  },
+
+  regExp(schema) {
+    return {
+      type: 'object.type.RegExp',
+      message: 'must be an array',
+      schema,
+      test: isRegExp,
     };
   },
 


### PR DESCRIPTION
Add the option to exclude dependencies based on a provided array of strings and regexp.  Based on a similar feature in [this webpack plugin](https://www.npmjs.com/package/license-checker-webpack-plugin). The closest I could get to doing this in by using a function for the `thirdParty.allow` would result in warnings or errors in the console. 