### PR TITLE
chore: Fixing Release

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -59,4 +59,3 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
               run: npx semantic-release --dry-run
-              working-directory: ./build

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -54,8 +54,6 @@ jobs:
 
             - run: npm run build
 
-            - run: cp LICENSE package.json README.md build
-
             - name: Release 🚀
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "lint": "gulp lint",
     "clean": "gulp clean",


### PR DESCRIPTION
It appears that for whatever reason, the build is not aligned correctly:
- package.json should include dist folder in files (it references this directly in places)
- README.md and LICENSE are auto bundled (no cp required), so removed from ci-cd